### PR TITLE
feat(SDL2): Adding SDL2 as a proper dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,15 +19,20 @@ pub fn build(b: *std.Build) void {
         .name = "zigout",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = .{ .src_path = .{ .sub_path = "src/main.zig", .owner = b } },
         .target = target,
         .optimize = optimize,
     });
 
-    exe.addIncludePath(std.Build.LazyPath{ .path = "/opt/homebrew/include/" });
-    exe.addLibraryPath(std.Build.LazyPath{ .path = "/opt/homebrew/lib/" });
+    const SDL2 = b.dependency("SDL2", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    exe.addIncludePath(.{ .dependency = .{ .dependency = SDL2, .sub_path = "include" } });
+    exe.linkLibrary(SDL2.artifact("SDL2"));
+
     exe.linkLibC();
-    exe.linkSystemLibrary("SDL2");
 
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
@@ -60,7 +65,7 @@ pub fn build(b: *std.Build) void {
     // Creates a step for unit testing. This only builds the test executable
     // but does not run it.
     const unit_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = .{ .src_path = .{ .sub_path = "src/main.zig", .owner = b } },
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,7 @@
+.{ .name = "Zigout", .version = "0.0.1", .paths = .{
+    "src/",
+    "build.zig",
+    "build.zig.zon",
+    "README.md",
+    "LICENSE",
+}, .dependencies = .{ .SDL2 = .{ .url = "https://github.com/allyourcodebase/SDL/archive/refs/heads/main.zip", .hash = "1220c8b7fffe055e95a991cbaf5d86b4d5ea380294b0b4326b2ee46110613cf7972e" } } }


### PR DESCRIPTION
### TL;DR

- Updated `build.zig` to integrate SDL2 as a managed dependency.
- Added `build.zig.zon` for Zig package manager.
- Refactored path management for better modularity.

### What changed?

- Modified `build.zig` to use `b.dependency` for managing SDL2.
- Changed `root_source_file` to use `src_path` with `sub_path` and `owner` for better abstraction.
- Removed hardcoded include and library paths, replaced with SDL2 dependency paths.
- Introduced `build.zig.zon` for Zig package management.

### How to test?

1. Fetch the latest code from the repository.
2. Run `zig build` to ensure the project builds successfully.
3. Verify SDL2 is being linked correctly by checking the build output and ensuring the application runs as expected.

### Why make this change?

- To improve dependency management by leveraging Zig's package manager.
- To make the build script more maintainable and modular by reducing hardcoded paths.
- To set the foundation for managing future dependencies in a similar manner.

---

