### PR TITLE
chore(typo): Fix `SLD` to `SDL`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -143,7 +143,7 @@ pub fn main() !void {
     defer c.SDL_DestroyWindow(window);
 
     if (window == null) {
-        print("SLD Create window failed: {s}", .{c.SDL_GetError()});
+        print("SDL Create window failed: {s}", .{c.SDL_GetError()});
         return SDLError.FailedCreatingWindow;
     }
 


### PR DESCRIPTION
Corrected typo from 'SLD Create window failed' to 'SDL Create window failed' in the error message.

---

