### PR TITLE
[ZIG-17]: Refactor: Collision

### DIFF
--- a/src/constants.zig
+++ b/src/constants.zig
@@ -1,0 +1,2 @@
+pub const WIDTH: i32 = 1280;
+pub const HEIGHT: i32 = 800;

--- a/src/errors.zig
+++ b/src/errors.zig
@@ -1,0 +1,9 @@
+pub const SDLError = error{
+    FailedInit,
+    FailedCreatingWindow,
+    FailedGettingEvent,
+};
+
+pub const GameError = error{
+    BallOutOfBounds,
+};

--- a/src/helpers.zig
+++ b/src/helpers.zig
@@ -1,0 +1,182 @@
+const C = @import("constants.zig");
+const E = @import("errors.zig");
+
+const c = @cImport({
+    @cInclude("SDL2/SDL.h");
+});
+
+const std = @import("std");
+
+const print = std.debug.print;
+
+const Position = struct {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+
+    t: i32,
+    r: i32,
+    b: i32,
+    l: i32,
+
+    pub fn create(x: i32, y: i32, w: i32, h: i32) Position {
+        return .{
+            .x = x,
+            .y = y,
+            .w = w,
+            .h = h,
+
+            .t = y,
+            .r = x + w,
+            .b = y + h,
+            .l = x,
+        };
+    }
+
+    pub fn update(self: *Position, x: ?i32, y: ?i32) void {
+        if (x != null) {
+            self.x = x.?;
+        }
+
+        if (y != null) {
+            self.y = y.?;
+        }
+
+        if (self.x <= 0) {
+            self.x = 0;
+        }
+
+        if (self.x + self.w >= C.WIDTH) {
+            self.x = C.WIDTH - self.w;
+        }
+
+        self.t = self.y;
+        self.r = self.x + self.w;
+        self.b = self.y + self.h;
+        self.l = self.x;
+    }
+
+    pub fn to_rect(self: *Position) c.SDL_Rect {
+        return c.SDL_Rect{ .w = self.w, .h = self.h, .x = self.x, .y = self.y };
+    }
+
+    pub fn is_overlapping(self: *Position, other: Position) bool {
+        const is_x_overlapping = (self.r >= other.l and self.r <= other.r) or (self.l <= other.r and self.l >= other.l) or (self.r >= other.r and self.l <= other.l);
+        const is_y_overlapping = (self.b >= other.t and self.b <= other.b) or (self.t <= other.b and self.t >= other.t) or (self.b >= other.b and self.t <= other.t);
+
+        return is_x_overlapping and is_y_overlapping;
+    }
+};
+
+pub const Ball = struct {
+    position: Position,
+    old_position: Position,
+
+    dx: i32,
+    dy: i32,
+
+    pub fn create(x: i32, y: i32, speed: i32) Ball {
+        const position = Position.create(x, y, 10, 10);
+        const old_position = Position.create(x, y, 10, 10);
+
+        return .{ .position = position, .old_position = old_position, .dx = speed, .dy = speed };
+    }
+
+    pub fn update_position(self: *Ball) void {
+        self.old_position = self.position;
+
+        self.position.update(self.position.x + self.dx, self.position.y + self.dy);
+    }
+
+    pub fn handle_collision(self: *Ball, paddle: *Paddle) E.GameError!void {
+        var change_dx = false;
+        var change_dy = false;
+
+        if (self.position.l <= 0) {
+            self.position.update(0, null);
+            change_dx = true;
+        }
+
+        if (self.position.r >= C.WIDTH) {
+            self.position.update(C.WIDTH - self.position.w, null);
+            change_dx = true;
+        }
+
+        if (self.position.t <= 0) {
+            self.position.update(null, 0);
+            change_dy = true;
+        }
+
+        if (self.position.b >= C.HEIGHT) {
+            print("GAME OVER!", .{});
+            return E.GameError.BallOutOfBounds;
+        }
+
+        const is_overlapping = self.position.is_overlapping(paddle.position);
+
+        if (is_overlapping == false) {
+            if (change_dx) {
+                self.dx *= -1;
+            }
+
+            if (change_dy) {
+                self.dy *= -1;
+            }
+
+            return;
+        }
+
+        const is_from_left = self.position.r >= paddle.position.l and self.old_position.r <= paddle.old_position.l;
+        if (is_from_left) {
+            self.position.update(paddle.position.l, null);
+            change_dx = true;
+        }
+
+        const is_from_right = self.position.l <= paddle.position.r and self.old_position.l >= paddle.old_position.r;
+        if (is_from_right) {
+            self.position.update(paddle.position.r, null);
+            change_dx = true;
+        }
+
+        const is_from_top = self.position.b >= paddle.position.t and self.old_position.b <= paddle.old_position.t;
+        if (is_from_top) {
+            self.position.update(null, paddle.position.t);
+            change_dy = true;
+        }
+
+        const is_from_bottom = self.position.t <= paddle.position.b and self.old_position.t >= paddle.old_position.b;
+        if (is_from_bottom) {
+            self.position.update(null, paddle.position.b);
+            change_dy = true;
+        }
+
+        if (change_dx) {
+            self.dx *= -1;
+        }
+
+        if (change_dy) {
+            self.dy *= -1;
+        }
+    }
+};
+
+pub const Paddle = struct {
+    position: Position,
+    old_position: Position,
+
+    speed: i32,
+
+    pub fn create(x: i32, y: i32) Paddle {
+        const position = Position.create(x, y, 200, 20);
+        const old_position = Position.create(x, y, 200, 20);
+
+        return .{ .position = position, .old_position = old_position, .speed = 20 };
+    }
+
+    pub fn update_position(self: *Paddle, speed: i32) void {
+        self.old_position = self.position;
+
+        self.position.update(self.position.x + speed, null);
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,3 +1,7 @@
+const C = @import("constants.zig");
+const E = @import("errors.zig");
+const H = @import("helpers.zig");
+
 const c = @cImport({
     @cInclude("SDL2/SDL.h");
 });
@@ -5,86 +9,6 @@ const c = @cImport({
 const std = @import("std");
 
 const print = std.debug.print;
-
-const WIDTH: i32 = 1280;
-const HEIGHT: i32 = 800;
-
-const SDLError = error{
-    FailedInit,
-    FailedCreatingWindow,
-    FailedGettingEvent,
-};
-
-const GameError = error{
-    BallOutOfBounds,
-};
-
-const Ball = struct {
-    radius: i32 = 10,
-    x: i32 = WIDTH / 2 + 5,
-    y: i32 = HEIGHT / 2 + 5,
-    dx: i32 = 5,
-    dy: i32 = 5,
-
-    pub fn update_position(self: *Ball) void {
-        self.x += self.dx;
-        self.y += self.dy;
-    }
-
-    pub fn to_rect(self: Ball) c.SDL_Rect {
-        return c.SDL_Rect{ .w = self.radius, .h = self.radius, .x = self.x, .y = self.y };
-    }
-};
-
-const Paddle = struct {
-    width: i32 = 200,
-    height: i32 = 20,
-    x: i32 = WIDTH / 2 - 50,
-    y: i32 = HEIGHT - 30,
-    speed: i32 = 20,
-
-    pub fn is_colliding(self: Paddle, ball: *Ball) bool {
-        // TODO: Double check if this is correct!
-        // (https://github.com/rafaelrene/zigout/issues/17) TODO: Update to correctly calculate reflection
-        // (https://github.com/rafaelrene/zigout/issues/16) TODO: Move to ball
-        const is_x_overlapping = self.x <= ball.x + ball.radius and self.x + self.width >= ball.x;
-        const is_y_overlapping = self.y <= ball.y + ball.radius and self.y + self.height >= ball.y;
-
-        return is_x_overlapping and is_y_overlapping;
-    }
-
-    pub fn update_position(self: *Paddle, delta_x: i32) void {
-        if (self.x + self.width + delta_x > WIDTH) {
-            self.x = WIDTH - self.width;
-            return;
-        }
-
-        if (self.x + delta_x < 0) {
-            self.x = 0;
-            return;
-        }
-
-        self.x += delta_x;
-    }
-
-    pub fn to_rect(self: Paddle) c.SDL_Rect {
-        return c.SDL_Rect{ .w = self.width, .h = self.height, .x = self.x, .y = self.y };
-    }
-};
-
-const Brick = struct {
-    width: i32,
-    height: i32,
-    x: i32,
-    y: i32,
-
-    pub fn is_colliding(self: Brick, ball: Ball) bool {
-        const is_x_overlapping = self.x <= ball.x + ball.radius and self.x + self.width >= ball.x;
-        const is_y_overlapping = self.y <= ball.y + ball.radius and self.y + self.height >= ball.y;
-
-        return is_x_overlapping and is_y_overlapping;
-    }
-};
 
 fn is_quit(event: *c.SDL_Event) bool {
     return switch (event.type) {
@@ -94,7 +18,7 @@ fn is_quit(event: *c.SDL_Event) bool {
     };
 }
 
-fn handle_paddle_keyboard_events(keyboard: [*c]const u8, paddle: *Paddle) void {
+fn handle_paddle_keyboard_events(keyboard: [*c]const u8, paddle: *H.Paddle) void {
     if (keyboard[c.SDL_SCANCODE_A] != 0) {
         paddle.update_position(-paddle.speed);
         return;
@@ -106,46 +30,21 @@ fn handle_paddle_keyboard_events(keyboard: [*c]const u8, paddle: *Paddle) void {
     }
 }
 
-fn handle_ball_bounce(paddle: *Paddle, ball: *Ball) GameError!void {
-    if (ball.x + ball.radius >= WIDTH) {
-        ball.dx = -5;
-    }
-
-    if (ball.x - ball.radius <= 0) {
-        ball.dx = 5;
-    }
-
-    if (ball.y - ball.radius <= 0) {
-        ball.dy = 5;
-    }
-
-    if (paddle.is_colliding(ball)) {
-        ball.dy = -5;
-    }
-
-    if (ball.y + ball.radius >= HEIGHT) {
-        print("GAME OVER!", .{});
-        return GameError.BallOutOfBounds;
-    }
-
-    ball.update_position();
-}
-
 pub fn main() !void {
     const init = c.SDL_Init(c.SDL_INIT_VIDEO);
     defer c.SDL_Quit();
 
     if (init < 0) {
         print("SDL Init failed: {s}", .{c.SDL_GetError()});
-        return SDLError.FailedInit;
+        return E.SDLError.FailedInit;
     }
 
-    const window = c.SDL_CreateWindow("Zigout", c.SDL_WINDOWPOS_CENTERED, c.SDL_WINDOWPOS_CENTERED, WIDTH, HEIGHT, c.SDL_WINDOW_SHOWN);
+    const window = c.SDL_CreateWindow("Zigout", c.SDL_WINDOWPOS_CENTERED, c.SDL_WINDOWPOS_CENTERED, C.WIDTH, C.HEIGHT, c.SDL_WINDOW_SHOWN);
     defer c.SDL_DestroyWindow(window);
 
     if (window == null) {
         print("SDL Create window failed: {s}", .{c.SDL_GetError()});
-        return SDLError.FailedCreatingWindow;
+        return E.SDLError.FailedCreatingWindow;
     }
 
     _ = c.SDL_UpdateWindowSurface(window);
@@ -159,8 +58,8 @@ pub fn main() !void {
 
     var event: c.SDL_Event = undefined;
 
-    var paddle = Paddle{};
-    var ball = Ball{};
+    var paddle = H.Paddle.create(C.WIDTH / 2 - 100, C.HEIGHT - 30);
+    var ball = H.Ball.create(C.WIDTH / 2 - 5, C.HEIGHT / 2 - 5, 5);
 
     while (true) {
         _ = c.SDL_PollEvent(&event);
@@ -171,20 +70,22 @@ pub fn main() !void {
 
         handle_paddle_keyboard_events(keyboard, &paddle);
 
-        _ = handle_ball_bounce(&paddle, &ball) catch |err| switch (err) {
-            GameError.BallOutOfBounds => break,
+        _ = ball.handle_collision(&paddle) catch |err| switch (err) {
+            E.GameError.BallOutOfBounds => break,
         };
+
+        ball.update_position();
 
         _ = c.SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
         _ = c.SDL_RenderClear(renderer);
 
         // NOTE: Draw paddle
         _ = c.SDL_SetRenderDrawColor(renderer, 255, 255, 255, 255);
-        _ = c.SDL_RenderFillRect(renderer, &paddle.to_rect());
+        _ = c.SDL_RenderFillRect(renderer, &paddle.position.to_rect());
 
         // NOTE: Draw ball
         _ = c.SDL_SetRenderDrawColor(renderer, 255, 0, 0, 255);
-        _ = c.SDL_RenderFillRect(renderer, &ball.to_rect());
+        _ = c.SDL_RenderFillRect(renderer, &ball.position.to_rect());
 
         c.SDL_RenderPresent(renderer);
         c.SDL_Delay(1000 / 60);


### PR DESCRIPTION

    ### TL;DR

    This PR refactors the `Ball` and `Paddle` logic out from `main.zig` into separate modules, `constants.zig`, `errors.zig`, and `helpers.zig`.

    ### What changed?

    - Introduced `constants.zig` to hold game constants like screen `WIDTH` and `HEIGHT`.
    - Added `errors.zig` for custom error types related to the game.
    - Created `helpers.zig` to handle `Ball` and `Paddle` logic along with their respective methods.
    - Updated `main.zig` to utilize these new modules.

    ### How to test?

    Run the game to ensure:
    - The ball moves and bounces correctly within screen bounds.
    - The paddle can be moved using the A and D keys.
    - The game ends when the ball moves out of the screen at the bottom.

    ### Why make this change?

    Improves code organization and maintainability by separating concerns into distinct modules.
    

---

